### PR TITLE
feat: Buchen-Button auch bei Summe 0,00€ anzeigen

### DIFF
--- a/src/bounty/generalUi/BookingInfo.js
+++ b/src/bounty/generalUi/BookingInfo.js
@@ -52,7 +52,8 @@ function UserButton({user, openUserSelectCallback}) {
 
 export default function BookingInfo({show, user, openUserSelectCallback, booking, allProducts, setProducts, reset, submit}) {
     const {oldBalance, newBalance, correction, cashPayment} = booking;
-    const hasInput = user != null && (newBalance!==oldBalance || correction!==0 || cashPayment!==0)
+    const hasSelectedProducts = allProducts?.some(({amount}) => amount !== 0);
+    const hasInput = user != null && (newBalance!==oldBalance || correction!==0 || cashPayment!==0 || hasSelectedProducts)
 
     return(
     <Offcanvas className="" style={{width: '370px'}} show={show} placement={'end'} backdrop={false} scroll={true}>


### PR DESCRIPTION
Button erscheint nun sobald mindestens ein Artikel ausgewählt wurde, unabhängig davon ob die Gesamtsumme 0,00€ ergibt.

Closes #80

 ## Test plan
      - [ ] Gratis-Artikel auswählen → Buchen-Button erscheint
      - [ ] Artikel auswählen die sich auf 0,00€ aufheben → Buchen-Button erscheint
      - [ ] Normalen Artikel auswählen → Buchen-Button erscheint wie bisher